### PR TITLE
Bug #14183 recipes/editにフロントエンドでファイルサイズの validation

### DIFF
--- a/app/assets/stylesheets/recipes/form.css.scss
+++ b/app/assets/stylesheets/recipes/form.css.scss
@@ -166,6 +166,14 @@ form.recipe-form {
       }
     }
   }
+
+  #filesize-caution {
+    display: none;
+    margin-top: 40px;
+    color: red;
+    font-size: 21px;
+  }
+
   .mce-tinymce {
     position: relative;
     top: -27px;

--- a/app/views/recipes/_form.html.slim
+++ b/app/views/recipes/_form.html.slim
@@ -49,6 +49,12 @@
     #making
       == render "status_form", f: f
 
+  #filesize-caution
+    p
+      'File Size Limit Exceed on an upload(6MB).
+    p
+      'You have to divide the file uploading or have to change the uploaded files on this session to less size ones.
+
   == f.submit
 
     / NOTE: temporary not shown

--- a/app/views/recipes/edit.html.slim
+++ b/app/views/recipes/edit.html.slim
@@ -37,6 +37,31 @@ main#recipes-edit
         setStatusReassocToken e.field
         makeSortableWay e.field.find(".ways")
 
+      UPLOAD_LIMIT = 6 * 1000 * 1000
+
+      checkFileSizeLimit = ->
+        sum_of_filesize = 0
+        thumb_files = $("#recipe_photo")[0].files
+        if thumb_files.length > 0
+          sum_of_filesize += thumb_files[0].size
+        $(".file-field").each ->
+          if $(this).parents(".fields").css("display") != "none"
+            if $(this)[0].files.length > 0
+              sum_of_filesize += $(this)[0].files[0].size
+        submitButton = $("main#recipes-edit input").last()
+        if sum_of_filesize > UPLOAD_LIMIT
+          $("#filesize-caution").css "display", "block"
+          submitButton.attr "disabled", true
+        else
+          $("#filesize-caution").css "display", "none"
+          submitButton.attr "disabled", false
+
+      $(document).on "change", "form.recipe-form", ->
+        checkFileSizeLimit()
+
+      $(document).on "click", "a.remove_nested_fields", ->
+        checkFileSizeLimit()
+
       $("#making").sortable({
         items       : "> .fields",
         placeholder : "ui-state-highlight",
@@ -46,4 +71,3 @@ main#recipes-edit
       })
       makeSortableWay $(".ways")
       $("#making").disableSelection()
-


### PR DESCRIPTION
レシピの画像をキャンセルする部分がないので、それは別のコミットで対応します。
あと、アップロードできるファイルサイズの上限は今のところ、6MBでよいのでしたっけ？
