### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
http://editorconfig.org/

この `.editorconfig` ファイルを置くことにより、[Vim](https://github.com/editorconfig/editorconfig-vim)や[Atom](https://github.com/sindresorhus/atom-editorconfig)、[Sublime Text](https://github.com/sindresorhus/editorconfig-sublime)などのエディタで、インデントサイズの設定や行末の余分なホワイトスペースの削除などを、自動で行ってくれるようになります。
