### PR TITLE
fixed #521 (一時的) Edit Project を混乱なく使えるようにする

### DIFF
--- a/app/views/projects/_basic_informations.html.slim
+++ b/app/views/projects/_basic_informations.html.slim
@@ -10,8 +10,8 @@ section#basic-informations
 
     .description-box
       .visual style="background-image: url('#{@project.figures.first.try :content}')"
-        - if @project.figures.first.is_a?(Figure::Video) && @project.figures.first.video_id.present?
-          iframe src="#{@project.figures.first.youtube_embed_url}"
+        - if @project.figures.first.link.length >= 0
+          iframe src="#{@project.figures.first.link}"
 
       .description
         h1

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -17,14 +17,12 @@
     #project-summary
       section.visual style="background-image: url('#{@project.figures.first.try :content}'); background-size: cover;" data-no-image-url="url(#{asset_path 'fallback/noise-7ms-a.gif'})"
         .video-form-wrapper
-          == link_to "Upload Image File…", "", title: "upload-image", id: "photo-upload-btn", class: "btn"
           == f.fields_for :figures do |ff|
             == ff.select :_type, [["Photo", Figure::Photo.name], ["Video", Figure::Video.name]]
             == ff.file_field :content
-            == ff.text_field :link
+            == ff.text_field :link, placeholder: "Youtube link"
             == ff.hidden_field :content_cache
           == f.link_to_add "Add a figure", :figures
-          == link_to "×", "", title: "remove-image", id: "remove-image-btn", class: "btn"
 
       section.description
         h1


### PR DESCRIPTION
ひとまず Upload Image ボタンを消し、Figure に link が入っていればそのページを表示する
