### PR TITLE
Fix an error occurring in odd size animation GIF

### DIFF
--- a/app/uploaders/figure_uploader.rb
+++ b/app/uploaders/figure_uploader.rb
@@ -46,8 +46,8 @@ class FigureUploader < CarrierWave::Uploader::Base
   def add_play_btn(src_img)
     overlay_file = File.open(play_btn_path).read
     overlay_img =  MiniMagick::Image.read(overlay_file)
-    x = (src_img['width'] - overlay_img['width']) / 2
-    y = (src_img['height'] - overlay_img['height']) / 2
+    x = ((src_img['width'] - overlay_img['width']) / 2).floor
+    y = ((src_img['height'] - overlay_img['height']) / 2).floor
     img = src_img.composite overlay_img, 'png' do |c|
       c.channel 'A'
       c.alpha 'Activate'


### PR DESCRIPTION
奇数ピクセル数のアニメーションGIFを図表として添付した際、再生ボタンを付与する処理でエラーが発生していたのを修正

![image](https://user-images.githubusercontent.com/60980/37324670-d0d71262-26cd-11e8-8071-e5745762fd65.png)
