### PR TITLE
ファブ3Dコンテスト向けのプライバシーポリシー変更

### DIFF
--- a/app/views/static_pages/privacy.html.slim
+++ b/app/views/static_pages/privacy.html.slim
@@ -1,22 +1,25 @@
 #privacy.main
   #en
     h1 Fabble Privacy Policy
-    'We at Social Fablication Laboratory of KEIO University SFC (hereinafter referred to as the “We”, “Our”, or “Us”) will handle all user information concerned with our “Fabble” service and all its related services (hereinafter referred to collectively as the ‘Service(s)’) in accordance with the following.
+    'We at Social Fabrication Laboratory of KEIO University SFC (hereinafter referred to as the “We”, “Our”, or “Us”) will handle all user information concerned with our “Fabble” service and all its related services (hereinafter referred to collectively as the ‘Service(s)’) in accordance with the following.
 
     ol type="1"
       li
         hr
-        h2 Acquired Information and Scope of Use
-        'We shall use and acquire user information in the following ways:
         dl
+          dt Acquired Information and Scope of Use
+          dd 'We shall use and acquire user information in the following ways:
           dt Registered Information
           dd To allow users to use the Service as smoothly as possible, and to promote effortless communication between users, users may be asked to register additional details such as profile information (Service display names, profile photos, text etc.), full name, and date of birth etc. Furthermore, other users within the service can view profile and other information (in the form of photos, videos, text etc.) which the users themselves have registered or posted with the aim of sharing with other users. While submission is optional, if users decide not to provide such information, they may not be able to enjoy all or parts of the Service offered.
 
           dt Information about GitHub
-          dd Users can access our Service by using accouts registered with GitHub. We may access your information as provided on GitHub (for example, your accout name, profile photos, text, or contact imformation etc.) by using OAuth. However, We will acquire the information in most instances in accordance with your user account setteings and/or the privacy policies of GitHub. Therefore, the User will take notice what type of informaiton they are permitting us to access in GitHub.
+          dd Users can access our Service by using accounts registered with GitHub. We may access your information as provided on GitHub (for example, your account name, profile photos, text, or contact information etc.) by using OAuth. However, We will acquire the information in most instances in accordance with your user account settings and/or the privacy policies of GitHub. Therefore, the User will take notice what type of information they are permitting us to access in GitHub.
 
           dt User Contact Information
           dd We acquires user information including full name, email address, and phone number etc., to help establish the user’s identity, for examination into reported problems and to provide an appropriate response to those inquiries.
+
+          dt Cooperation for Fab 3D Contest
+          dd We cooperate on the project "Fab 3D Contest" hosted by Consortium for the Global Society with Planetary Fabbing in Keio University SFC through Service. When users apply for Fab 3D Contest through Service, we may provide Consortium for the Global Society with Planetary Fabbing in Keio University SFC with users' names and contact information we have acquired through Service for the purpose of enabling the committee to contact the applicants for the Contest. The information provided may be used by the executive committee of Fab 3D Contest, established within Consortium for the Global Society with Planetary Fabbing in Keio University SFC, to contact applicants. We also use users' names and contact information to contact users for the purpose of communicating about Fab 3D Contest. For the application for the Contest, please check the application terms for the Contest.
 
           dt Cookies
           dd To provide the best possible service to users, as well as for maintenance and security purposes, Cookies will be used to store user settings, to record access figures as well as monitoring usage patterns and statistics. Users can choose to deactivate Cookies, however in such circumstances users will not be able to use parts of the Service which require Cookies to be active such as those requiring users to login.
@@ -31,89 +34,110 @@
           dd Some of the Services may use location information transmitted from users' mobile phones/devices. We only uses such information within the scope that is necessary in order to provide the designated service. When users have not allowed their location information to be sent via the settings menu on their devices, location information will not be sent.
 
           dt Device Information
+          dd 'The users’ device information (PC or mobile hardware information etc.) may be acquired at times. This information shall be used for the provision of a better service, as well as for identification purposes and prevention of any unauthorized/fraudulent practices which interfere with normal Service operations. 'Furthermore, depending on whether users use an OS or mobile device, the details of the device information that We acquires will differ. Regarding the details of information that We can acquire, please refer to the manufacturer's or software provider's policies.
+
+
+      li
+        hr
+        dl
+          dt Purpose of User Information
+          dd For all other cases, We shall use the acquired personal information for the following purposes listed below:
+          ol type="a"
+            li to perform identity checks when a user makes an inquiry etc.
+            li to prevent any unauthorized/fraudulent use of the Service
+            li to offer an undisturbed and smooth Service to users
+            li to improve our Services
+            li to aggregate statistical data regarding the Service
+            li to conduct research and analysis aimed at reviewing our Services
+            li to enable Us to deal effectively with user inquiries
+            li to provide information regarding the Service etc., as well as advertising information from our partner businesses
+            li to provide new future developments regarding the Service
+            li to notify users of any other important information regarding the Service and to contact users where necessary
+            li to provide the executive committee of Fab 3D Contest with the names and contact information of users who have applied the Contest through Service for the purpose of cooperation for the Contest
+
+      li
+        hr
+        dl
+          dt Provision of Information
+          dd We will never provide user information to any third parties expect under the following circumstances:
+          ol type="a"
+            li when the user personally agrees to such provisions in advance
+            li when the law requires Us to do so
+            li when We finds sufficient enough reasons to believe that the user is violating the Terms of Service and We are forced to disclose the user's personal information in order to protect Our rights, properties, and/or services
+            li when it is necessary for the protection of a person's life, body, or property, and at such a time, when obtaining the user's prior consent is difficult
+            li when it is especially necessary for the improvement of public health or to promote the sound growth of children, and at such a time, when obtaining the user's prior consent is difficult
+            li when We are required to cooperate with a state institution, a local government, or an individual or a business operator entrusted by one in executing the affairs prescribed by laws and regulations, and at such a time, when obtaining the users prior consent could impede the aims of the authorities
+            li in cases where the user's personal information is revealed as a result of the succession of Our business in a merger, demerger, or business transfer, etc.
+
+        dl
+          dt Consent to Provision to Third Parties
+          dd We may provide the executive committee of Fab 3D Contest with the names and contact information of users who have applied for the Contest through Service for the purpose of enabling the committee to contact the applicants for the Contest. Users shall consent the provision of such information in advance to apply for the Contest.
+
+          - value='[Recipient]'
+
+          dt==value
+          dd Name: Consortium for the Global Society with Planetary Fabbing in Keio University SFC
+          dd Person in charge: Hiroya Tanaka, the chair of the executive committee of Fab 3D Contest
+          dd Contact:  fab3d-contest@sfc.keio.ac.jp
+
+      li
+        hr
+        dl
+          dt Information Delegation
+          dd We may entrust, to the extent We considers necessary to achieve the intended purpose concerning the use of the Service, the handling of personal information collected from users, in whole or in part, to a trustee. In such circumstances, We will adequately assess the eligibility of the trustee, impose a confidentiality agreement upon the trustee, and establish an appropriate information administration system.
+
+      li
+        hr
+        dl
+          dt Shared Use of Information
+          dd We may share the user's personal information with a business partner, when a business partner's cooperation is needed in order to keep providing the Service to the user.
+          dd In such circumstances, We will inform the user regarding the purpose of information sharing, the name of the business partner and information manager, as well as the type of shared information involved before sharing the user’s personal information with such a business partner.
+
+      li
+        hr
+        dl
+          dt User Rights
           dd
-            'The users’ device information (PC or mobile hardware information etc.) may be acquired at times. This information shall be used for the provision of a better service, as well as for identification purposes and prevention of any unauthorized/fraudulent practices which interfere with normal Service operations.
-            'Furthermore, depending on whether users use an OS or mobile device, the details of the device information that We acquires will differ. Regarding the details of information that We can acquire, please refer to the manufacturer's or software provider's policies.
+            ol type="a"
+              li Users may, at any time, confirm or correct their personal information such as Service display name, email address and/or password registered to the Service. Users can also delete their accounts by sending a request to Our Inquiries set forth in Article 10.
+              li When using account certification for other services such as GitHub, the link to said accounts can be cancelled.
+              li Users may, through the procedures determined by Us, send Us a request for the disclosure of personal information which the users cannot confirm/access via the Service. We, in turn shall disclose such information except under the following conditions:
+              ol type="i"
+                li when the disclosure is likely to harm the life, body, property or other rights or interests of the user or any other third party
+                li when the disclosure is likely to severely interfere with Our proper operation
+                li when disclosure itself would constitute a violation of laws and/or regulations
+                li when We are unable to verify the user’s ownership of the personal information requested for disclosure.
+              li After the disclosure, users may, through the procedures determined by Us, send Us a request to correct, add or delete the user’s personal information, if the users find personal information registered with Us to be incorrect. Under such circumstances, We shall swiftly investigate the request to achieve the desired user intention and correct, add or delete the personal information on the basis of Our findings.When users request the disclosure by Us of their personal information that is unable to be confirmed/accessed though the Service, We may charge the users a certain fee for the disclosure procedures. The users can choose freely whether or not they will provide Us with their personal information, however the users may be unable to use a part of the Service until they have provided Us with the necessary information.
 
       li
         hr
-        h2 Purpose of User Information
-        'For all other cases, We shall use the acquired personal information for the following purposes listed below:
-        ol type="a"
-          li to perform identity checks when a user makes an inquiry etc.
-          li to prevent any unauthorized/fraudulent use of the Service
-          li to offer an undisturbed and smooth Service to users
-          li to improve our Services
-          li to aggregate statistical data regarding the Service
-          li to conduct research and analysis aimed at reviewing our Services
-          li to enable Us to deal effectively with user inquiries
-          li to provide information regarding the Service etc., as well as advertising information from our partner businesses
-          li to provide new future developments regarding the Service
-          li to notify users of any other important information regarding the Service and to contact users where necessary
+        dl
+          dt Withdrawal from Our Services
+          dd Upon withdrawing from our Services, when a user account is deleted, all user information will be disposed of in the correct manner in accordance with the law and Our regulations.
 
       li
         hr
-        h2 Provision of Information
-        'We will never provide user information to any third parties expect under the following circumstances:
-        ol type="a"
-          li when the user personally agrees to such provisions in advance
-          li when the law requires Us to do so
-          li when We finds sufficient enough reasons to believe that the user is violating the Terms of Service and We are forced to disclose the user's personal information in order to protect Our rights, properties, and/or services
-          li when it is necessary for the protection of a person's life, body, or property, and at such a time, when obtaining the user's prior consent is difficult
-          li when it is especially necessary for the improvement of public health or to promote the sound growth of children, and at such a time, when obtaining the user's prior consent is difficult
-          li when We are required to cooperate with a state institution, a local government, or an individual or a business operator entrusted by one in executing the affairs prescribed by laws and regulations, and at such a time, when obtaining the users prior consent could impede the aims of the authorities
-          li in cases where the user's personal information is revealed as a result of the succession of Our business in a merger, demerger, or business transfer, etc.
+        dl
+          dt Personal Information of Children
+          dd Users younger than 15 years of age must obtain consent from their parents or legal representatives before they provide any personal information in order to use the Service.
 
       li
         hr
-        h2 Information Delegation
-        'We may entrust, to the extent We considers necessary to achieve the intended purpose concerning the use of the Service, the handling of personal information collected from users, in whole or in part, to a trustee. In such circumstances, We will adequately assess the eligibility of the trustee, impose a confidentiality agreement upon the trustee, and establish an appropriate information administration system.
+        dl
+          dt Modifications to this Privacy Policy
+          dd This Privacy Policy may be revised periodically. Users will be notified of important changes in a recognizable manner.
 
       li
         hr
-        h2 Shared Use of Information
-        'We may share the user's personal information with a business partner, when a business partner's cooperation is needed in order to keep providing the Service to the user.
-        'In such circumstances, We will inform the user regarding the purpose of information sharing, the name of the business partner and information manager, as well as the type of shared information involved before sharing the user’s personal information with such a business partner.
-
-      li
-        hr
-        h2 User Rights
-        ol type="a"
-          li Users may, at any time, confirm or correct their personal information such as Service display name, email address and/or password registered to the Service. Users can also delete their accounts by sending a request to Our Inquiries set forth in Article 10.
-          li When using account certification for other services such as GitHub, the link to said accounts can be cancelled.
-          li
-            'Users may, through the procedures determined by Us, send Us a request for the disclosure of personal information which the users cannot confirm/access via the Service. We, in turn shall disclose such information except under the following conditions:
-            ol type="i"
-              li when the disclosure is likely to harm the life, body, property or other rights or interests of the user or any other third party
-              li when the disclosure is likely to severely interfere with Our proper operation
-              li when disclosure itself would constitute a violation of laws and/or regulations
-              li when We are unable to verify the user’s ownership of the personal information requested for disclosure.
-          li After the disclosure, users may, through the procedures determined by Us, send Us a request to correct, add or delete the user’s personal information, if the users find personal information registered with Us to be incorrect. Under such circumstances, We shall swiftly investigate the request to achieve the desired user intention and correct, add or delete the personal information on the basis of Our findings.When users request the disclosure by Us of their personal information that is unable to be confirmed/accessed though the Service, We may charge the users a certain fee for the disclosure procedures. The users can choose freely whether or not they will provide Us with their personal information, however the users may be unable to use a part of the Service until they have provided Us with the necessary information.
-
-      li
-        hr
-        h2 Withdrawal from Our Services
-        'Upon withdrawing from our Services, when a user account is deleted, all user information will be disposed of in the correct manner in accordance with the law and Our regulations.
-
-      li
-        hr
-        h2 Personal Information of Children
-        'Users younger than 15 years of age must obtain consent from their parents or legal representatives before they provide any personal information in order to use the Service.
-
-      li
-        hr
-        h2 Modifications to this Privacy Policy
-        'This Privacy Policy may be revised periodically. Users will be notified of important changes in a recognizable manner.
-
-      li
-        hr
-        h2 Inquiries
-        'If users have any uncertainty about this Privacy Policy or questions, complaints, or comments on the handling of personal information related to the Service, users are asked to contact us blow;
-        'support@fabble.cc
+        dl
+          dt Inquiries
+          dd If users have any uncertainty about this Privacy Policy or questions, complaints, or comments on the handling of personal information related to the Service, users are asked to contact us blow;
+          dd support@fabble.cc
 
     .sign
       p Prescribed on Sep. 1, 2014
       p Revised on Oct. 15, 2015
+      p Revised on Aug. 15, 2019
       p Social Fablication Laboratory of KEIO University SFC
 
   #jp
@@ -123,22 +147,23 @@
     ol type="1"
       li
         hr
-        h2 取得する情報及び利用方法
-        '当団体は、本サービスにおいて次のように情報を取得及び利用いたします。
+        dl
+          dt 取得する情報及び利用方法
+          dd 当団体は、本サービスにおいて次のように情報を取得及び利用いたします。
         dl
           dt ご登録いただく情報
           dd 本サービスの円滑利用やユーザー間で円滑にコミュニケーションを行っていただく等の目的で、プロフィール情報（本サービス上での表示名、アイコン画像、テキスト等）等をご登録いただく場合がございます。なお、本サービス上で表示するためのプロフィール情報や他のユーザーへ公開するためにユーザー自身が登録、投稿した情報（写真、映像、テキスト等）は他のユーザーも閲覧できます。ご登録はユーザーの任意ですが、ご登録いただけない場合、本サービスまたは本サービスの一部をご利用いただけない場合がございます。
-
           dt GitHub上の情報
           dd ユーザーは、GitHubにおいて登録されたアカウントを使用して、本サービスにアクセスすることができます。当団体は、OAuthを利用して、GitHub上におけるあなたの情報（例えば、あなたのアカウント名、アイコン画像、プロフィール、連絡先等）にアクセスすることがあります。ただし、ここで当団体が取得する情報については、多くの場合、GitHubのアカウント設定やGitHubのプライバシー・ポリシーに従って処理されるので、ユーザーは当団体にアクセスすることを許可することになる情報がどのようなものなのか確認してください。
 
           dt お問い合わせ
           dd 氏名、メールアドレス、電話番号等を取得する可能性があります。これらの情報はお問い合わせに対する調査、返答、及びご本人確認のために利用いたします。
 
+          dt Fab3Dコンテスト実施への協力
+          dd 当団体は、本サービスを通じて、Fab3Dコンテスト（慶應義塾大学SFC研究所ファブ地球社会コンソーシアム主催）の実施に協力しています。ユーザーが本サービスを通じて同コンテストに応募した場合、同コンテストの応募者への連絡に利用する目的で、当団体が取得したユーザーの氏名、連絡先をファブ地球社会コンソーシアムに提供することがあります。提供した情報は、同コンテストの事務局であるFabコンテスト実行委員会（ファブ地球社会コンソーシアム内に設置）が応募者への連絡に利用します。また、同コンテスト応募者に対して、当団体から同コンテストについての連絡[倉崎1]の目的で、当団体がユーザーの氏名及び連絡を利用することがあります。同コンテストへの応募については、同コンテスト応募規約をご確認ください。
+
           dt クッキー（Cookie）
-          dd
-            'ユーザーの設定内容の保存等ユーザーの利便性向上のため、セッションの維持及び保護等セキュリティのため、ユーザーが利用した本サービスに対する訪問回数及び利用形態、ユーザーの規模等の把握により、より良いサービスを提供するためにクッキーを利用いたします。
-            'ユーザーはクッキーの使用可否を選択できますが、クッキーの保存を拒む場合にはログインが必要なサービス等、本サービスの一部をご利用いただけない場合があります。
+          dd ユーザーの設定内容の保存等ユーザーの利便性向上のため、セッションの維持及び保護等セキュリティのため、ユーザーが利用した本サービスに対する訪問回数及び利用形態、ユーザーの規模等の把握により、より良いサービスを提供するためにクッキーを利用いたします。ユーザーはクッキーの使用可否を選択できますが、クッキーの保存を拒む場合にはログインが必要なサービス等、本サービスの一部をご利用いただけない場合があります。
 
           dt アナリティクス
           dd 当団体は、サービス改善を目的としたユーザー行動やトラフィックの解析のために、「Google アナリティクス」を利用しており、 ファーストパーティ cookie により匿名のトラフィックデータを収集しています。あくまで匿名のトラフィックデータであり、個人の特定などの心配はありませんのでご了承ください。
@@ -150,85 +175,101 @@
           dd PCや携帯電話等から送信される位置情報を取得する場合があります。ユーザーが該当サービスを利用された場合は、該当サービスに必要な範囲内で利用いたします。なお、携帯電話等の設定で位置情報の送信を許可していない場合は、位置情報は送信されません。
 
           dt 機器情報
-          dd
-            'ユーザーが利用される機器情報（端末の個体識別情報等）を取得する場合がございます。これらの情報はより良いサービス提供のため、またご本人確認や正常なサービス提供を妨害する不正行為防止のために利用いたします。
-            'なお、ユーザーが使用している機器またはOSに応じて、当団体が取得する機器情報の詳細は異なります。当団体が取得できる情報の詳細については、デバイスの製造元またはソフトウェア・プロバイダーのポリシーをご確認ください。
+          dd ユーザーが利用される機器情報（端末の個体識別情報等）を取得する場合がございます。これらの情報はより良いサービス提供のため、またご本人確認や正常なサービス提供を妨害する不正行為防止のために利用いたします。なお、ユーザーが使用している機器またはOSに応じて、当団体が取得する機器情報の詳細は異なります。当団体が取得できる情報の詳細については、デバイスの製造元またはソフトウェア・プロバイダーのポリシーをご確認ください。
 
       li
         hr
-        h2 情報の利用目的
-        '当団体は取得した個人情報を以下の目的で利用いたします。
-        ol type="a"
-          li ユーザーの本人確認のため
-          li 不正利用防止のため
-          li ユーザーが本サービスを円滑に利用できるようにするため
-          li 本サービスの改善のため
-          li 本サービス利用に関する統計データを作成するため
-          li 現在提供している本サービスまたは今後提供を検討している本サービスに関するアンケート実施のため
-          li ユーザーからのお問い合わせに対する対応のため
-          li 本サービスに関する情報等または当団体以外の事業者が広告主となる広告情報等を告知するため
-          li 今後の本サービスに関する新企画立案を行い提供するため
-          li その他本サービスに関する重要なお知らせ等、必要に応じた連絡を行うため
+        dl
+          dt 情報の利用目的
+          dd 当団体は取得した個人情報を以下の目的で利用いたします。
+          ol type="a"
+            li ユーザーの本人確認のため
+            li 不正利用防止のため
+            li ユーザーが本サービスを円滑に利用できるようにするため
+            li 本サービスの改善のため
+            li 本サービス利用に関する統計データを作成するため
+            li 現在提供している本サービスまたは今後提供を検討している本サービスに関するアンケート実施のため
+            li ユーザーからのお問い合わせに対する対応のため
+            li 本サービスに関する情報等または当団体以外の事業者が広告主となる広告情報等を告知するため
+            li 今後の本サービスに関する新企画立案を行い提供するため
+            li その他本サービスに関する重要なお知らせ等、必要に応じた連絡を行うため
+            li Fab3Dコンテスト実施に協力のために同コンテスト主催者に同コンテストに応募したユーザーの連絡先を提供するため
 
       li
         hr
-        h2 情報の提供
-        '当団体はユーザーの個人情報を下記の場合を除いて第三者に提供することはございません。
-        ol type="a"
-          li ご本人が事前に同意した場合
-          li 法律に基づく場合
-          li ユーザーが本サービスの利用規約に違反し、当団体弊社の権利、財産やサービス等を保護するために、個人情報を公開せざるをえないと判断するに足る十分な根拠がある場合
-          li 人の生命、身体または財産の保護のために必要がある場合であって、本人の同意を得ることが困難である場合
-          li 公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合であって、本人の同意を得ることが困難である場合
-          li 国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合であって、本人の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがある場合
-          li 合併、会社分割、営業譲渡その他の事由によって個人情報の提供を含む当団体の事業の承継が行われる場合
+        dl
+          dt 情報の提供
+          dd 当団体はユーザーの個人情報を下記の場合を除いて第三者に提供することはございません。
+          ol type="a"
+            li ご本人が事前に同意した場合
+            li 法律に基づく場合
+            li ユーザーが本サービスの利用規約に違反し、当団体弊社の権利、財産やサービス等を保護するために、個人情報を公開せざるをえないと判断するに足る十分な根拠がある場合
+            li 人の生命、身体または財産の保護のために必要がある場合であって、本人の同意を得ることが困難である場合
+            li 公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合であって、本人の同意を得ることが困難である場合
+            li 国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合であって、本人の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがある場合
+            li 合併、会社分割、営業譲渡その他の事由によって個人情報の提供を含む当団体の事業の承継が行われる場合
+  
+          dt 第三者提供への同意
+          dd 当団体は、Fab3Dコンテンストの主催者が応募者に連絡することを可能とする目的で、当該主催者に対し、本サービスを通じてFab３Dコンテストに応募したユーザーの氏名及び連絡先情報を提供します。ユーザーは予め当該提供に同意した上で、Fab3Dコンテストに応募する必要があります。
+          dd 【情報受領者】
+          dd 名称：慶應義塾大学SFC研究所ファブ地球社会コンソーシアム
+          dd 責任者：３DFabコンテスト実行委員会　委員長　田中浩也
+          dd 連絡先：fab3d-contest@sfc.keio.ac.jp
 
       li
         hr
-        h2 情報の預託
-        '当団体は利用目的の達成に必要な範囲内においてユーザーから取得した個人情報の全部または一部を業務委託先に預託することがございます。その際、業務委託先としての適格性を十分審査するとともに、契約にあたって守秘義務に関する事項等を規定し、情報が適正に管理される体制作りを行います。
+        dl
+          dt 情報の預託
+          dd 当団体は利用目的の達成に必要な範囲内においてユーザーから取得した個人情報の全部または一部を業務委託先に預託することがございます。その際、業務委託先としての適格性を十分審査するとともに、契約にあたって守秘義務に関する事項等を規定し、情報が適正に管理される体制作りを行います。
 
       li
         hr
-        h2 情報の共同利用
-        '本サービスを提供するにあたり、当団体と共同して業務を行うビジネスパートナーが必要な場合には、ユーザーの個人情報をそのビジネスパートナーと共同利用することがあります。この場合に当団体は、利用目的、ビジネスパートナーの名称、情報の種類、管理者の名称についてユーザーに公表した上で共同利用することといたします。
+        dl
+          dt 情報の共同利用
+          dd 本サービスを提供するにあたり、当団体と共同して業務を行うビジネスパートナーが必要な場合には、ユーザーの個人情報をそのビジネスパートナーと共同利用することがあります。この場合に当団体は、利用目的、ビジネスパートナーの名称、情報の種類、管理者の名称についてユーザーに公表した上で共同利用することといたします。
 
       li
         hr
-        h2 利用者の権利
-        ol type="a"
-          li ユーザーはいつでもご登録されている本サービス上の表示名、メールアドレス、パスワード等の情報を、本サービスサイト上で確認、訂正することができます。また、アカウントを削除することができます。
-          li GitHub等の他のサービスのアカウントによる認証をご利用の場合には、かかるアカウントへのリンクを解除することができます。
-          li
-            'ユーザーは当団体に対し、サービスサイト上で確認できない個人情報の開示を求める場合、当団体が別途定めた手続きに従って、次の場合を除き開示を請求することができます。
-            ol type="i"
-              li 開示することで本人または第三者の生命、身体、財産その他の権利利益を害するおそれがある場合
-              li 開示することで当団体の業務の適正な実施に著しい支障を及ぼすおそれがある場合
-              li 開示することが法令に違反することとなる場合
-              li 開示の請求がご本人からであることが確認できない場合
-          li 開示の結果、ユーザーが当団体保有の個人情報の内容が事実でないと判断した場合は、当団体が別途定めた手続きに従って、個人情報の訂正・追加・削除を請求することができます。その場合、当団体は利用目的の達成に必要な範囲内で遅滞なく調査を行い、その結果に基づき当該個人情報の訂正・追加・削除を行います。なお、サービスサイト上で確認できない個人情報の開示を請求される場合には、当団体が別途定めた手続きに従って開示手数料をいただく場合がございます。ユーザーから当団体への個人情報の提供は任意ですが、必要な情報をご提供いただけない場合、本サービスの一部を利用できない場合がございます。
+        dl
+          dt 利用者の権利
+          ol type="a"
+            li ユーザーはいつでもご登録されている本サービス上の表示名、メールアドレス、パスワード等の情報を、本サービスサイト上で確認、訂正することができます。また、アカウントを削除することができます。
+            li GitHub等の他のサービスのアカウントによる認証をご利用の場合には、かかるアカウントへのリンクを解除することができます。
+            li
+              'ユーザーは当団体に対し、サービスサイト上で確認できない個人情報の開示を求める場合、当団体が別途定めた手続きに従って、次の場合を除き開示を請求することができます。
+              ol type="i"
+                li 開示することで本人または第三者の生命、身体、財産その他の権利利益を害するおそれがある場合
+                li 開示することで当団体の業務の適正な実施に著しい支障を及ぼすおそれがある場合
+                li 開示することが法令に違反することとなる場合
+                li 開示の請求がご本人からであることが確認できない場合
+            li 開示の結果、ユーザーが当団体保有の個人情報の内容が事実でないと判断した場合は、当団体が別途定めた手続きに従って、個人情報の訂正・追加・削除を請求することができます。その場合、当団体は利用目的の達成に必要な範囲内で遅滞なく調査を行い、その結果に基づき当該個人情報の訂正・追加・削除を行います。なお、サービスサイト上で確認できない個人情報の開示を請求される場合には、当団体が別途定めた手続きに従って開示手数料をいただく場合がございます。ユーザーから当団体への個人情報の提供は任意ですが、必要な情報をご提供いただけない場合、本サービスの一部を利用できない場合がございます。
+  
+      li
+        hr
+        dl
+          dt 退会者の情報
+          dd 本サービスのアカウントを削除した場合、ユーザー情報は関連法規および社内規定に従って適切に処理いたします。
 
       li
         hr
-        h2 退会者の情報
-        '本サービスのアカウントを削除した場合、ユーザー情報は関連法規および社内規定に従って適切に処理いたします。
+        dl
+          dt お子様の個人情報について
+          dd 15歳未満のユーザーが本サービスを利用し、個人情報を入力される場合には保護者の方の同意のもとに行っていただけますようお願いいたします。
 
       li
         hr
-        h2 お子様の個人情報について
-        '15歳未満のユーザーが本サービスを利用し、個人情報を入力される場合には保護者の方の同意のもとに行っていただけますようお願いいたします。
+        dl
+          dt 本プライバシーポリシーの改定
+          dd 本プライバシーポリシーは改定されることがあります。重要な変更にあたってはユーザーに対してわかりやすい方法にて改定内容を告知いたします。
 
       li
         hr
-        h2 本プライバシーポリシーの改定
-        '本プライバシーポリシーは改定されることがあります。重要な変更にあたってはユーザーに対してわかりやすい方法にて改定内容を告知いたします。
-
-      li
-        hr
-        h2 お問い合わせ
-        '本プライバシーポリシーに関してご不明な点がある場合、本サービスにおける個人情報の取り扱いに関するご質問・苦情・ご相談等があります場合は下記までご連絡ください。
-        'support@fabble.cc
+        dl
+          dt お問い合わせ
+          dd 本プライバシーポリシーに関してご不明な点がある場合、本サービスにおける個人情報の取り扱いに関するご質問・苦情・ご相談等があります場合は下記までご連絡ください。
+          dd support@fabble.cc
     .sign
       p 2014年9月1日　作成
       p 2015年10月15日　改定
-      p 慶応大学SFCソーシャルファブリケーションラボ
+      p 2019年8月15日　改定
+      p 慶應義塾大学SFC研究所ソーシャルファブリケーションラボ


### PR DESCRIPTION
ファブ3Dコンテストの応募受付にfabble.ccを利用するために、プライバシーポリシーの変更が必要になったので、加筆修正を行った。
