### PR TITLE
ファブ3Dコンテスト終了に伴う変更

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,7 +1,7 @@
 section#layouts-header
   .inner
-    .band(style="padding: 10px; background: #3BA3FE; text-align: center;")
-      = link_to "FAB 3D CONTEST 2019 エントリー受付中!!", "https://www.fab3d.org/", target: "_blank", style: "color: #FFF;"
+/    .band(style="padding: 10px; background: #3BA3FE; text-align: center;")
+/      = link_to "FAB 3D CONTEST 2019 エントリー受付中!!", "https://www.fab3d.org/", target: "_blank", style: "color: #FFF;"
     .container
       #logo
         = link_to "", root_path, class: "logo"


### PR DESCRIPTION
ヘッダーのティッカーを削除した。23日0時に本番サイトに適用する