### PR TITLE
Add sentry-raven

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem 'stl', github: 'oshimaryo/stl-ruby'
 gem 'stl2gif', github: 'takeyuwebinc/stl2gif', branch: 'develop'
 gem 'mathn' # Used in geometry gem in stl gem
 
+gem "sentry-raven"
+
 group :development, :test do
   gem 'bullet'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,8 @@ GEM
     schmooze (0.1.6)
     scout_apm (2.6.8)
       parser
+    sentry-raven (3.0.0)
+      faraday (>= 1.0)
     simplecov (0.17.0)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -487,6 +489,7 @@ DEPENDENCIES
   sanitize
   sass-rails
   scout_apm
+  sentry-raven
   simplecov
   slack-notifier
   slim-rails

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.dsn = ENV.fetch('SENTRY_DSN') { nil }
+end


### PR DESCRIPTION
#1515 の後

エラートラッキングのためのSentryを導入

`SENTRY_DSN` 環境変数を設定しているとき、Sentryにエラー情報を送信します。
