### PR TITLE
Enable caching

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -10,7 +10,7 @@ class ProjectsController < ApplicationController
   def index
     projects = Project.published.includes(:figures, :owner)
     @popular_projects = ProjectAccessStatistic.access_ranking.merge(projects).limit(10)
-    @featured_groups = Group.access_ranking
+    @featured_groups = Rails.cache.fetch("Group.access_ranking", expires_in: 1.hour) { Group.access_ranking }
     @recent_projects = projects.order(updated_at: :desc).limit(12)
   end
 

--- a/app/views/projects/_basic_informations.html.slim
+++ b/app/views/projects/_basic_informations.html.slim
@@ -42,6 +42,7 @@ section#basic-informations
 
   section.body
     - if @project.figures.present?
+      - cache [@project.figures] do
       - if @project.figures.first.content.present?
         - figures = @project.figures.to_a
         figure.visual.carousel.slide data-ride="carousel" data-interval="false" id="carousel-#{@project.id}"

--- a/app/views/projects/_popular_projects.html.slim
+++ b/app/views/projects/_popular_projects.html.slim
@@ -4,4 +4,4 @@
       .inner
         h2.title POPULAR PROJECTS
         p.description この1ヶ月で人気のプロジェクトのランキングです
-    = render partial: "project_card", collection: @popular_projects, as: "project", locals: { show_rank_badge: true }
+    = render partial: "project_card", collection: @popular_projects, as: "project", locals: { show_rank_badge: true }, cached: -> (project) { [project.cache_key, 'show_rank_badge'] }

--- a/app/views/projects/_popular_projects.html.slim
+++ b/app/views/projects/_popular_projects.html.slim
@@ -4,4 +4,4 @@
       .inner
         h2.title POPULAR PROJECTS
         p.description この1ヶ月で人気のプロジェクトのランキングです
-    = render partial: "project_card", collection: @popular_projects, as: "project", locals: { show_rank_badge: true }, cached: -> (project) { [project.cache_key, 'show_rank_badge'] }
+    = render partial: "project_card", collection: @popular_projects, as: "project", locals: { show_rank_badge: true }, cached: -> (project) { ['show_rank_badge', project] }

--- a/app/views/projects/_project_comments.html.slim
+++ b/app/views/projects/_project_comments.html.slim
@@ -4,28 +4,29 @@ section#project-comments
     .comments-wrapper
       ul.comments
         - @project_comments.each.with_index(1) do |comment, i|
-          li.comment id="project-comment-#{comment.id}"
-            .left
-              = link_to image_tag(comment.user.avatar.thumb.url, class: 'avatar'), owner_path(comment.user), title: comment.user.name
-            .right
-              .wrapper
-                .header
-                  span.number.header-content
-                    = format "No.%03d", i
-                  span.owner.header-content
-                    = link_to_if !comment.user.is_deleted?, comment.user.name, owner_path(comment.user)
-                      '退会ユーザー
+          - cache [comment, comment.user, current_user] do
+            li.comment id="project-comment-#{comment.id}"
+              .left
+                = link_to image_tag(comment.user.avatar.thumb.url, class: 'avatar'), owner_path(comment.user), title: comment.user.name
+              .right
+                .wrapper
+                  .header
+                    span.number.header-content
+                      = format "No.%03d", i
+                    span.owner.header-content
+                      = link_to_if !comment.user.is_deleted?, comment.user.name, owner_path(comment.user)
+                        '退会ユーザー
 
-                  span.created-at.header-content
-                    = "Posted date: "
-                    span.date
-                      = l(comment.created_at.to_date)
+                    span.created-at.header-content
+                      = "Posted date: "
+                      span.date
+                        = l(comment.created_at.to_date)
 
-                  - if current_user && comment.manageable_by?(current_user)
-                    span.comment-tools
-                      = link_to "delete", project_project_comment_path(comment.project.owner, comment.project.id, comment), method: :delete, data: { confirm: "Are you sure to remove this comment?" }, class: "btn delete-btn delete-comment"
-                .body
-                  == Sanitize.clean auto_link(comment.body, sanitize: false), Sanitize::Config::RELAXED
+                    - if current_user && comment.manageable_by?(current_user)
+                      span.comment-tools
+                        = link_to "delete", project_project_comment_path(comment.project.owner, comment.project.id, comment), method: :delete, data: { confirm: "Are you sure to remove this comment?" }, class: "btn delete-btn delete-comment"
+                  .body
+                    == Sanitize.clean auto_link(comment.body, sanitize: false), Sanitize::Config::RELAXED
       - if current_user
         = form_with(scope: :project_comment, url: project_project_comments_path(@project.owner, @project.id), id: 'project-comment-form', class: 'comment-form', local: true) do |f|
           .columns

--- a/app/views/projects/_recent_projects.html.slim
+++ b/app/views/projects/_recent_projects.html.slim
@@ -3,4 +3,4 @@
     .lang-jp 最近のプロジェクト
     .lang-en Recent Projects
   .container.project-cards
-    = render partial: "project_card", collection: @recent_projects, as: "project"
+    = render partial: "project_card", collection: @recent_projects, as: "project", cached: true

--- a/app/views/projects/_recipe_cards.html.slim
+++ b/app/views/projects/_recipe_cards.html.slim
@@ -30,7 +30,8 @@ section#recipe-cards
     ul#recipe-card-list.card-list
       - @states.each do |state|
         li class="card-wrapper #{state.htmlclass}-wrapper"
-          = render "states/state", state: state, owner: @owner, project: @project
+          - cache [state, state.annotations, state.comments, current_user] do
+            = render "states/state", state: state, owner: @owner, project: @project
 
     .article-column.sp
       - if can? :edit, @project

--- a/app/views/projects/_usages.html.slim
+++ b/app/views/projects/_usages.html.slim
@@ -6,9 +6,10 @@ section#usages
     ul#usage-list.card-list
       - @usages.each do |usage|
         li
-          = render "components/usage", card: usage,
-                                       delete_url: project_usage_path(@owner, @project, usage),
-                                       edit_url: edit_project_usage_path(@owner, @project, usage)
+          - cache [usage, current_user] do
+            = render "components/usage", card: usage,
+                delete_url: project_usage_path(@owner, @project, usage),
+                edit_url: edit_project_usage_path(@owner, @project, usage)
 
     - if current_user
       = link_to "+ Add Usage", new_project_usage_path(@owner, @project), remote: true,

--- a/app/views/projects/search.html.slim
+++ b/app/views/projects/search.html.slim
@@ -16,8 +16,7 @@
       h2.title
         ="Searched Projects: #{@query}"
       ul#searched-projects.projects
-        - @projects.each do |project|
-          = render "project", project: project
+        = render partial: "project", collection: @projects, as: "project", cached: true
       = paginate @projects
 
       - if @projects.blank?

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,3 +6,7 @@ end
 every 1.day, at: ['00:30'] do
   rake 'statistic:daily'
 end
+
+every 1.hour do
+  runner 'Rails.cache.clear'
+end


### PR DESCRIPTION
パーシャルテンプレートが多く、ビューのレンダリングに時間がかかっているので、この対策としてコレクションキャッシュおよびフラグメントキャッシュを導入します。

これによりレンダリングコストの抑制による高速化を期待できます。