### PR TITLE
プロジェクトフォークについてにセキュリティ修正

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -85,6 +85,11 @@ class ProjectsController < ApplicationController
 
   def fork
     target_owner = Owner.find(params[:owner_id])
+    unless can?(:manage, target_owner)
+      render_404
+      return
+    end
+
     original_project = Project.find_with(params[:owner_name], params[:project_id])
     forked_project = original_project.fork_for!(target_owner)
     path = project_path(target_owner, forked_project)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -91,6 +91,11 @@ class ProjectsController < ApplicationController
     end
 
     original_project = Project.find_with(params[:owner_name], params[:project_id])
+    unless can?(:read, original_project)
+      render_404
+      return
+    end
+
     forked_project = original_project.fork_for!(target_owner)
     path = project_path(target_owner, forked_project)
 

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -213,49 +213,59 @@ describe ProjectsController, type: :controller do
   describe 'POST #fork' do
     subject { post :fork, params: { owner_name: project.owner, project_id: project, owner_id: target_owner.slug } }
 
-    let!(:project) { FactoryBot.create(:project, :public) }
-
     before { sign_in(current_user) }
 
-    context 'target_owner is a User' do
-      let(:target_owner) { FactoryBot.create(:user) }
+    describe 'check the target_owner' do
+      let!(:project) { FactoryBot.create(:project, :public) }
 
-      context 'when the user is himself' do
-        let(:current_user) { target_owner }
-
-        it { is_expected.to redirect_to project_path(target_owner, Project.last) }
-        it { expect{ subject }.to change{ Project.count }.by(1) }
-      end
-
-      context 'when the user is not himself' do
-        let(:current_user) { FactoryBot.create(:user) }
-
-        it { expect{ subject }.to_not change{ Project.count } }
-      end
-    end
-
-    context 'target_owner is a Group' do
-      let(:current_user) { FactoryBot.create(:user) }
-      let(:target_owner) { FactoryBot.create(:group) }
-
-      context 'when the user is in' do
-        context 'when the role is an administrator' do
-          before { FactoryBot.create(:membership, role: "admin", group: target_owner, user: current_user) }
+      context 'target_owner is a User' do
+        let(:target_owner) { FactoryBot.create(:user) }
+  
+        context 'when the user is himself' do
+          let(:current_user) { target_owner }
   
           it { is_expected.to redirect_to project_path(target_owner, Project.last) }
           it { expect{ subject }.to change{ Project.count }.by(1) }
         end
-
-        context 'when the role is a editor' do
-          before { FactoryBot.create(:membership, role: "editor", group: target_owner, user: current_user) }
-
+  
+        context 'when the user is not himself' do
+          let(:current_user) { FactoryBot.create(:user) }
+  
           it { expect{ subject }.to_not change{ Project.count } }
         end
       end
-
-      context 'when the user is not in' do
-        it { expect{ subject }.to_not change{ Project.count } }
+  
+      context 'target_owner is a Group' do
+        let(:current_user) { FactoryBot.create(:user) }
+        let(:target_owner) { FactoryBot.create(:group) }
+  
+        context 'when the user is in' do
+          context 'when the role is an administrator' do
+            before { FactoryBot.create(:membership, role: "admin", group: target_owner, user: current_user) }
+    
+            it { is_expected.to redirect_to project_path(target_owner, Project.last) }
+            it { expect{ subject }.to change{ Project.count }.by(1) }
+          end
+  
+          context 'when the role is a editor' do
+            before { FactoryBot.create(:membership, role: "editor", group: target_owner, user: current_user) }
+  
+            it { expect{ subject }.to_not change{ Project.count } }
+          end
+        end
+  
+        context 'when the user is not in' do
+          it { expect{ subject }.to_not change{ Project.count } }
+        end
       end
+    end
+
+    describe 'check the project visibility' do
+      let!(:project) { FactoryBot.create(:project, :private) }
+      let(:target_owner) { FactoryBot.create(:user) }
+      let(:current_user) { target_owner }
+  
+      it { expect{ subject }.to_not change{ Project.count } }
     end
   end
 


### PR DESCRIPTION
## 概要

フォークリクエスト送信時のパラメータを変更することで次の操作が可能になるセキュリティ上の問題があったのでこれを修正します。

- 自分以外のアカウントに対してフォークを行える不具合
- プライベートプロジェクトをフォークできる不具合

## 変更内容

### 自分以外のアカウントに対してフォークを行える不具合

#### 事象

Fork先 `owner_id=xxxxx` に第三者のslugを指定することで、そのユーザー/グループのプロジェクトとしてForkできます。

#### 対策

Fork先がログイン中のユーザー自身か自身が管理しているグループのどちらかであることを確認するようにしました。

### プライベートプロジェクトをフォークできる不具合

#### 事象

Fork先 `owner_id=xxxxx` に第三者のslugを指定することで、そのユーザー/グループのプロジェクトとしてForkできます。

#### 対策

Fork先がログイン中のユーザー自身か自身が管理しているグループのどちらかであることを確認するようにしました。



