### PR TITLE
Revert "デプロイの際にcrontabファイルを更新する"

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,8 +6,7 @@ set :rvm_type, :system
 set :rvm_ruby_version, '2.6.6'
 set :assets_roles, [:web, :app]
 set :npm_flags, '--silent --no-progress' # Not use --production to install devDependencies
-+set :whenever_command, -> { "cd #{release_path} && bundle exec whenever --update-crontab -i gitfab2" }
-+set :whenever_roles, ->{ :cron }
+set :whenever_command, -> { "cd #{release_path} && bundle exec whenever" }
 
 if ENV['DEPLOY_BRANCH']
   set :branch, ENV['DEPLOY_BRANCH']

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
 role :app, %w(deploy@localhost)
 role :web, %w(deploy@localhost)
 role :db,  %w(deploy@localhost)
-server 'localhost', user: 'deploy', roles: %w(web app cron)
+server 'localhost', user: 'deploy', roles: %w(web app)
 set :rails_env, 'production'
 set :linked_files, %w{config/database.yml config/secrets.yml}

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,6 +1,6 @@
 role :app, %w(deploy@localhost)
 role :web, %w(deploy@localhost)
 role :db,  %w(deploy@localhost)
-server 'localhost', user: 'deploy', roles: %w(web app cron)
+server 'localhost', user: 'deploy', roles: %w(web app)
 set :rails_env, 'staging'
 set :linked_files, %w{config/database.yml config/secrets.yml}


### PR DESCRIPTION
Reverts webdino/gitfab2#1522

```bash
$ bundle exec cap production deploy:check
(Backtrace restricted to imported tasks)
cap aborted!
SyntaxError: config/deploy.rb:9: syntax error, unexpected tSYMBEG, expecting do or '{' or '('
+set :whenever_command, -> { "cd #{...
     ^
Tasks: TOP => production
(See full trace by running task with --trace)
```