### PR TITLE
グループメンバーの追加と削除においてのセキュリティ修正

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,6 +1,11 @@
 class MembersController < ApplicationController
   def create
     @group = Group.find(params[:group_id])
+    unless can?(:manage, @group)
+      render_404
+      return
+    end
+
     user = User.friendly.find(params[:member_name])
     membership = user.join_to(@group)
     if membership

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -5,7 +5,8 @@ class MembershipsController < ApplicationController
   end
 
   def update
-    membership = Membership.find(params[:id])
+    @user = User.friendly.find params[:user_id]
+    membership = @user.memberships.find(params[:id])
     if can?(:update, membership) && membership.update(params.require(:membership).permit(:role))
       render json: { success: true }
     else
@@ -16,7 +17,7 @@ class MembershipsController < ApplicationController
   def destroy
     @user = User.friendly.find params[:user_id]
     @membership = @user.memberships.find params[:id]
-    if @membership.deletable?
+    if can?(:manage, @membership.group) && @membership.deletable?
       @membership.destroy
     else
       render json: { success: false, message: 'You can not remove this member.' }

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,19 +1,60 @@
 # frozen_string_literal: true
 
 describe MembersController, type: :controller do
-  let(:group) { FactoryBot.create :group }
-  let(:user) { FactoryBot.create :user }
-
-  subject { response }
 
   describe 'POST create' do
-    before do
-      post :create, params: { group_id: group.id, member_name: user.name }, xhr: true
-      user.reload
+    subject { post :create, params: { group_id: group.id, member_name: user.to_param }, xhr: true }
+
+    context 'when an administrator is signed in' do
+      let(:group) { FactoryBot.create :group }
+      let(:user) { FactoryBot.create :user }
+
+      before do
+        current_user = FactoryBot.create(:user)
+        sign_in(current_user)
+
+        FactoryBot.create(:membership, group: group, user: current_user, role: "admin")
+      end
+  
+      it { is_expected.to have_http_status(:ok) }
+      it { is_expected.to render_template :create }
+      it { expect { subject }.to change(user.memberships, :count).by(1) }
     end
-    it { is_expected.to render_template :create }
-    it 'has 1 membership' do
-      expect(user.memberships.size).to eq 1
+
+    context 'when an editor is signed in' do
+      let(:group) { FactoryBot.create :group }
+      let(:user) { FactoryBot.create :user }
+
+      before do
+        current_user = FactoryBot.create(:user)
+        sign_in(current_user)
+
+        FactoryBot.create(:membership, group: group, user: current_user, role: "editor")
+      end
+  
+      it { is_expected.to_not have_http_status(:ok) }
+      it { expect { subject }.to_not change(user.memberships, :count) }
+    end
+
+    context 'when not a member is signed in' do
+      let(:group) { FactoryBot.create :group }
+      let(:user) { FactoryBot.create :user }
+
+      before do
+        current_user = FactoryBot.create(:user) 
+        sign_in(current_user)
+      end
+  
+      it { is_expected.to_not have_http_status(:ok) }
+      it { expect { subject }.to_not change(user.memberships, :count) }
+    end
+
+    context 'when an anonymous' do
+      let(:group) { FactoryBot.create :group }
+      let(:user) { FactoryBot.create :user }
+
+      it { is_expected.to_not have_http_status(:ok) }
+      it { expect { subject }.to_not change(user.memberships, :count) }
     end
   end
 end

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 describe MembershipsController, type: :controller do
-  let(:user) { FactoryBot.create :user }
-  subject { response }
 
   describe 'GET index' do
+    let(:user) { FactoryBot.create :user }
+    subject { response }
     before do
       sign_in user
       Group.create name: 'foo'
@@ -14,56 +14,134 @@ describe MembershipsController, type: :controller do
   end
 
   describe 'PATCH update' do
-    subject { patch :update, params: { user_id: user.id, id: membership.id, membership: params } }
-    let(:membership) { FactoryBot.create(:membership) }
-    let(:user) { membership.user }
-    before { sign_in user }
+    subject { patch :update, params: { user_id: user.to_param, id: membership.id, membership: membership_params } }
+    let(:group) { FactoryBot.create :group }
+    let(:user) { FactoryBot.create :user }
+    let(:membership) { FactoryBot.create(:membership, group: group, user: user, role: "editor") }
 
-    context 'with valid params' do
-      let(:params) { { role: 'admin' } }
-      it do
-        subject
-        expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: true })
+    context 'when an administrator is signed in' do
+      before do
+        current_user = FactoryBot.create(:user)
+        sign_in(current_user)
+
+        FactoryBot.create(:membership, group: group, user: current_user, role: "admin")
+      end
+
+      context 'with valid params' do
+        let(:membership_params) { { role: 'admin' } }
+
+        it do
+          subject
+          expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: true })
+        end
+
+        it { expect { subject }.to change { membership.reload.role }.from("editor").to("admin") }
+      end
+  
+      context 'with valid params' do
+        let(:membership_params) { { role: 'invalid' } }
+        it do
+          subject
+          expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: false })
+        end
       end
     end
 
-    context 'with valid params' do
-      let(:params) { { role: 'invalid' } }
-      it do
-        subject
-        expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: false })
+    context 'when an editor is signed in' do
+      before do
+        current_user = FactoryBot.create(:user)
+        sign_in(current_user)
+
+        FactoryBot.create(:membership, group: group, user: current_user, role: "editor")
       end
+
+      let(:membership_params) { { role: 'admin' } }
+
+      it { expect { subject }.to_not change { membership.reload.role } }
+    end
+
+    context 'when an anonymous' do
+      let(:membership_params) { { role: 'admin' } }
+
+      it { expect { subject }.to_not change { membership.reload.role } }
     end
   end
 
   describe 'DELETE destroy' do
-    subject { delete :destroy, params: { user_id: user.id, id: membership.id } }
+    context 'when an administrator is signed in' do
+      let!(:current_membership) { FactoryBot.create(:membership, group: group, user: current_user, role: "admin") }
+      let(:current_user) { FactoryBot.create(:user) }
+      let(:group) { FactoryBot.create(:group) }
 
-    let!(:group) { FactoryBot.create(:group)}
-    let!(:membership) { user.memberships.create(group: group, role: 'admin') }
+      before do
+        sign_in(current_user)
+      end
 
-    before { sign_in user }
+      context 'when 2 group members (admins)' do
+        # Another user's membership
+        before { FactoryBot.create(:membership, group: group, role: 'admin') }
+  
+        subject { delete :destroy, params: { user_id: current_user.to_param, id: current_membership.id } }
 
-    context 'when 2 group members (admins)' do
-      # Another user's membership
-      before { FactoryBot.create(:membership, group: group, role: 'admin') }
+        it 'deletes 1 membership' do
+          expect { subject }.to change { Membership.count }.by(-1)
+        end
+      end
+  
+      context 'when 2 group members (admin and editor)' do
+        before { FactoryBot.create(:membership, group: group, role: 'editor') }
 
-      it 'deletes 1 membership' do
-        expect { subject }.to change { Membership.count }.by(-1)
+        subject { delete :destroy, params: { user_id: current_user.to_param, id: current_membership.id } }
+  
+        it 'does NOT delete admin membership' do
+          expect { subject }.not_to change { Membership.count }
+        end
+      end
+  
+      context 'when 1 group member' do
+        subject { delete :destroy, params: { user_id: current_user.to_param, id: current_membership.id } }
+  
+        it 'does NOT delete membership' do
+          expect { subject }.not_to change { Membership.count }
+        end
       end
     end
 
-    context 'when 2 group members (admin and editor)' do
-      before { FactoryBot.create(:membership, group: group, role: 'editor') }
+    context 'when an editor is signed in' do
+      let!(:current_membership) { FactoryBot.create(:membership, group: group, user: current_user, role: "editor") }
+      let(:current_user) { FactoryBot.create(:user) }
+      let(:group) { FactoryBot.create(:group) }
 
-      it 'does NOT delete admin membership' do
-        expect { subject }.not_to change { Membership.count }
+      before do
+        sign_in(current_user)
+      end
+
+      context 'when 2 group members (admins)' do
+        # Another user's membership
+        before { FactoryBot.create(:membership, group: group, role: 'admin') }
+  
+        subject { delete :destroy, params: { user_id: current_user.to_param, id: current_membership.id } }
+
+        it 'does NOT delete the membership' do
+          expect { subject }.to_not change(Membership, :count)
+        end
       end
     end
 
-    context 'when 1 group member' do
-      it 'does NOT delete membership' do
-        expect { subject }.not_to change { Membership.count }
+    context 'when an anonymous' do
+      let!(:membership) { FactoryBot.create(:membership, group: group, user: user, role: "editor") }
+      let(:user) { FactoryBot.create(:user) }
+      let(:group) { FactoryBot.create(:group) }
+
+      context 'when 2 group members (admins)' do
+        # Another user's membership
+        before { FactoryBot.create(:membership, group: group, role: 'admin') }
+  
+        subject { delete :destroy, params: { user_id: user.to_param, id: membership.id } }
+
+        it 'does NOT delete the membership' do
+          expect { subject }.to_not change(Membership, :count)
+        end
       end
     end
   end


### PR DESCRIPTION
## 概要

グループメンバーの追加と削除において権限チェックがなかった不具合を修正


## 変更内容

- グループのメンバー追加時にログイン中ユーザーがグループの管理権限を持つことを確認するように
- グループのメンバー削除時にログイン中ユーザーがグループの管理権限を持つことを確認するように
- グループのメンバー管理の権限についてのspecを追加
