### PR TITLE
ステートの追加と削除においてのセキュリティ修正

### DIFF
--- a/app/controllers/states_controller.rb
+++ b/app/controllers/states_controller.rb
@@ -44,9 +44,13 @@ class StatesController < ApplicationController
 
   def to_annotation
     state = @project.states.find(params[:state_id])
-    parent_state = @project.states.find(params[:dst_state_id])
-    annotation = state.to_annotation!(parent_state)
-    render json: {'$oid' => annotation.id}
+    if can?(:manage, state)
+      parent_state = @project.states.find(params[:dst_state_id])
+      annotation = state.to_annotation!(parent_state)
+      render json: {'$oid' => annotation.id}
+    else
+      render json: { success: false }, status: 400
+    end
   end
 
   private


### PR DESCRIPTION
## 概要

ステートの追加と削除における権限の振る舞いのspecを追加

## 変更内容

- プロジェクトのステートの権限についてのspecを追加
- ステートについての権限がなくてもアノテーションへの変換ができる不具合を修正
