### PR TITLE
コラボレーターの追加と削除についてのセキュリティ修正

### DIFF
--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -1,12 +1,17 @@
 class CollaborationsController < ApplicationController
   def create
+    project = Project.find_with(params[:owner_name], params[:project_id])
+    unless can?(:manage, project)
+      render json: { success: false }, status: 400
+      return
+    end
+
     collaborator = Owner.find_by(params[:collaborator_name])
     unless collaborator
       render json: { success: false }, status: 400
       return
     end
 
-    project = Project.find_with(params[:owner_name], params[:project_id])
     @collaboration = collaborator.collaborations.build(project: project)
     if @collaboration.save
       notify_users(project, collaborator)

--- a/spec/controllers/collaborations_controller_spec.rb
+++ b/spec/controllers/collaborations_controller_spec.rb
@@ -12,51 +12,76 @@ describe CollaborationsController, type: :controller do
 
     let(:project) { FactoryBot.create(:project) }
 
-    before { sign_in(project.owner) }
+    before { sign_in(current_user) }
 
-    context 'with valid params' do
-      let(:collaborator_name) { FactoryBot.create(:user).slug }
-      it do
-        is_expected.to be_successful
-                  .and render_template(:create)
+    context 'When current_user is the project owner' do
+      let(:current_user) { project.owner }
+    
+      context 'with valid params' do
+        let(:collaborator_name) { FactoryBot.create(:user).slug }
+        it do
+          is_expected.to be_successful
+                    .and render_template(:create)
+        end
+        it { expect{ subject }.to change{ Collaboration.count }.by(1) }
       end
-      it { expect{ subject }.to change{ Collaboration.count }.by(1) }
+  
+      context 'with invalid params' do
+        let(:collaborator_name) { 'not_exist' }
+        it do
+          is_expected.to have_http_status(:bad_request)
+          response_body = JSON.parse(response.body, symbolize_names: true)
+          expect(response_body).to eq({ success: false })
+        end
+        it { expect{ subject }.not_to change{ Collaboration.count } }
+      end
     end
 
-    context 'with invalid params' do
-      let(:collaborator_name) { 'not_exist' }
-      it do
-        is_expected.to have_http_status(:bad_request)
-        response_body = JSON.parse(response.body, symbolize_names: true)
-        expect(response_body).to eq({ success: false })
+    context 'When current_user is not the project owner' do
+      let(:current_user) { FactoryBot.create(:user) }
+    
+      context 'with valid params' do
+        let(:collaborator_name) { FactoryBot.create(:user).slug }
+        it { is_expected.to_not be_successful }
+        it { expect{ subject }.to_not change{ Collaboration.count } }
       end
-      it { expect{ subject }.not_to change{ Collaboration.count } }
     end
   end
 
   describe 'DELETE destroy' do
     subject { delete :destroy, params: { id: collaboration.id }, xhr: true }
-    let(:collaboration) { FactoryBot.create(:collaboration) }
-    before { sign_in(collaboration.owner) }
+    let!(:collaboration) { FactoryBot.create(:collaboration) }
+    before { sign_in(current_user) }
 
-    context 'user can destroy a collaboration' do
-      it do
-        is_expected.to be_successful
-        response_body = JSON.parse(response.body, symbolize_names: true)
-        expect(response_body).to eq({ success: true, id: collaboration.id })
+    context 'When current_user is the collaborator' do
+      let(:current_user) { collaboration.owner }
+
+      context 'user can destroy a collaboration' do
+        it do
+          is_expected.to be_successful
+          response_body = JSON.parse(response.body, symbolize_names: true)
+          expect(response_body).to eq({ success: true, id: collaboration.id })
+        end
+        it { expect{ subject }.to change{ Collaboration.count }.by(-1) }
       end
-      it { expect{ subject }.to change{ Collaboration.count }.by(-1) }
+
+      context 'user cannot destroy a collaboration' do
+        before { collaboration.project.update!(is_deleted: true) }
+
+        it do
+          is_expected.to have_http_status(:bad_request)
+          response_body = JSON.parse(response.body, symbolize_names: true)
+          expect(response_body).to eq({ success: false })
+        end
+        it { expect{ subject }.not_to change{ Collaboration.count } }
+      end
     end
 
-    context 'user cannot destroy a collaboration' do
-      before { collaboration.project.update!(is_deleted: true) }
+    context 'When current_user is a user' do
+      let(:current_user) { FactoryBot.create(:user) }
 
-      it do
-        is_expected.to have_http_status(:bad_request)
-        response_body = JSON.parse(response.body, symbolize_names: true)
-        expect(response_body).to eq({ success: false })
-      end
-      it { expect{ subject }.not_to change{ Collaboration.count } }
+      it { is_expected.to_not be_successful }
+      it { expect{ subject }.to_not change{ Collaboration.count } }
     end
   end
 end


### PR DESCRIPTION
## 概要

コラボレーターの追加と削除における権限の振る舞いのspecを追加

## 変更内容

- プロジェクトのコラボレーター管理の権限についてのspecを追加
- プロジェクトの管理権限がなくても任意のユーザーをコラボレーターに追加できる不具合を修正
