### PR TITLE
グループへのメンバー追加についてのセキュリティ修正

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,13 +1,18 @@
 class MembersController < ApplicationController
   def create
     @group = Group.find(params[:group_id])
-    user = User.friendly.find(params[:member_name])
-    membership = user.join_to(@group)
-    if membership
-      @member = membership.user
-      membership.role = params[:role]
-      membership.save
-      render :create
+
+    if can?(:manage, @group)
+      user = User.friendly.find(params[:member_name])
+      membership = user.join_to(@group)
+      if membership
+        @member = membership.user
+        membership.role = params[:role]
+        membership.save
+        render :create
+      else
+        render json: { success: false }
+      end
     else
       render json: { success: false }
     end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,19 +1,50 @@
 # frozen_string_literal: true
 
 describe MembersController, type: :controller do
-  let(:group) { FactoryBot.create :group }
-  let(:user) { FactoryBot.create :user }
-
-  subject { response }
-
   describe 'POST create' do
-    before do
-      post :create, params: { group_id: group.id, member_name: user.name }, xhr: true
-      user.reload
+    let(:group) { FactoryBot.create :group }
+    let(:user) { FactoryBot.create :user }
+
+    subject { post :create, params: { group_id: group.id, member_name: user.name }, xhr: true }
+
+    context 'when current_user is the group administrator' do
+      before do
+        sign_in FactoryBot.create(:membership, group: group, role: 'admin').user
+      end
+      
+      it { is_expected.to render_template :create }
+      it 'creates a membership' do
+        expect { subject }.to change(user.memberships, :count).to eq 1
+      end
     end
-    it { is_expected.to render_template :create }
-    it 'has 1 membership' do
-      expect(user.memberships.size).to eq 1
+
+    context 'when current_user is the group editor' do
+      before do
+        sign_in FactoryBot.create(:membership, group: group, role: 'editor').user
+      end
+      
+      it { is_expected.to_not render_template :create }
+      it 'does not create a membership' do
+        expect { subject }.to_not change(user.memberships, :count)
+      end
+    end
+
+    context 'when current_user is not the group member' do
+      before do
+        sign_in FactoryBot.create(:user)
+      end
+      
+      it { is_expected.to_not render_template :create }
+      it 'does not create a membership' do
+        expect { subject }.to_not change(user.memberships, :count)
+      end
+    end
+
+    context 'when current_user is an anonymous' do
+      it { is_expected.to_not render_template :create }
+      it 'does not create a membership' do
+        expect { subject }.to_not change(user.memberships, :count)
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要

グループへのメンバー追加における権限の調整とspecの追加

## 変更内容

- グループへのメンバー追加における権限についてのspecを追加
- グループの管理権限がなくても任意のユーザーを任意のグループのメンバーに追加できる不具合を修正
