### PR TITLE
メモについてのセキュリティ修正

### DIFF
--- a/app/controllers/note_cards_controller.rb
+++ b/app/controllers/note_cards_controller.rb
@@ -20,7 +20,7 @@ class NoteCardsController < ApplicationController
 
   def create
     @note_card.description = view_context.auto_link @note_card.description, html: { target: '_blank' }
-    if @note_card.save
+    if can?(:create, @note_card) && @note_card.save
       @project.touch
       render :create
     else
@@ -40,7 +40,7 @@ class NoteCardsController < ApplicationController
       description = view_context.auto_link(note_card_params[:description], html: { target: '_blank' })
       auto_linked_params[:description] = description
     end
-    if @note_card.update auto_linked_params
+    if can?(:update, @note_card) && @note_card.update(auto_linked_params)
       @project.touch
       render :update
     else
@@ -49,7 +49,7 @@ class NoteCardsController < ApplicationController
   end
 
   def destroy
-    if @note_card.destroy
+    if can?(:destroy, @note_card) && @note_card.destroy
       @project.touch
       render json: { success: true }
     else

--- a/spec/controllers/note_cards_controller_spec.rb
+++ b/spec/controllers/note_cards_controller_spec.rb
@@ -21,112 +21,168 @@ describe NoteCardsController, type: :controller do
   end
 
   describe 'POST create' do
-    context 'without attachments' do
-      before do
-        post :create, params: { owner_name: user, project_id: project, note_card: new_note_card.attributes }, xhr: true
-        project.reload
-      end
-      it { is_expected.to render_template :create }
-      it 'has 1 note_card' do
-        expect(project.note_cards.size).to eq 1
-      end
-    end
-    context 'with attachments' do
-      before do
-        post :create, params: {
-          owner_name: user, project_id: project,
-          note_card: new_note_card.attributes.merge(
-            attachments_attributes: [FactoryBot.attributes_for(:attachment_material)]
-          )
-        }, xhr: true
-        project.reload
-      end
-      it "has 1 attachment of kind 'material'" do
-        note_card = project.note_cards.first
-        aggregate_failures do
-          expect(note_card.attachments.size).to eq 1
-          expect(note_card.attachments.first.kind).to eq('material')
-        end
-      end
-    end
-    context 'with incorrect params' do
-      before do
-        # Card::NoteCardのtitle, descriptionにはバリデーションがあるが
-        # card.js.coffeeのvalidateForm(event, is_note_card_form)でもalertを出している
-        post :create,
-          params: { owner_name: user, project_id: project, note_card: { title: '', description: '' } },
-          xhr: true
-      end
-      it do
-        aggregate_failures do
-          is_expected.to have_http_status(400)
-          expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: false })
-        end
-      end
-    end
-  end
+    context 'when current_user is a project owner' do
+      before { sign_in(user) }
 
-  describe 'PATCH update' do
-    context 'with correct params' do
-      let(:title_to_change) { '_foo' }
-      let(:description_to_change) { '_bar' }
-
-      context 'with a title only' do
+      context 'without attachments' do
         before do
-          patch :update,
-            params: { owner_name: user, project_id: project, id: note_card.id, note_card: { title: title_to_change } },
-            xhr: true
-          note_card.reload
+          post :create, params: { owner_name: user, project_id: project, note_card: new_note_card.attributes }, xhr: true
+          project.reload
         end
-        it { is_expected.to render_template :update }
-        it { expect(project.note_cards.first.title).to eq title_to_change }
+        it { is_expected.to render_template :create }
+        it 'has 1 note_card' do
+          expect(project.note_cards.size).to eq 1
+        end
       end
-      context 'with a title and a description' do
+      context 'with attachments' do
         before do
-          patch :update,
-            params: {
-              owner_name: user, project_id: project, id: note_card.id,
-              note_card: { title: title_to_change, description: description_to_change }
-            },
-            xhr: true
-          note_card.reload
+          post :create, params: {
+            owner_name: user, project_id: project,
+            note_card: new_note_card.attributes.merge(
+              attachments_attributes: [FactoryBot.attributes_for(:attachment_material)]
+            )
+          }, xhr: true
+          project.reload
         end
-        it { is_expected.to render_template :update }
-        it 'should change both a title and a description' do
+        it "has 1 attachment of kind 'material'" do
+          note_card = project.note_cards.first
           aggregate_failures do
-            note_card = project.note_cards.first
-            expect(note_card.title).to eq title_to_change
-            expect(note_card.description).to eq description_to_change
+            expect(note_card.attachments.size).to eq 1
+            expect(note_card.attachments.first.kind).to eq('material')
+          end
+        end
+      end
+      context 'with incorrect params' do
+        before do
+          # Card::NoteCardのtitle, descriptionにはバリデーションがあるが
+          # card.js.coffeeのvalidateForm(event, is_note_card_form)でもalertを出している
+          post :create,
+            params: { owner_name: user, project_id: project, note_card: { title: '', description: '' } },
+            xhr: true
+        end
+        it do
+          aggregate_failures do
+            is_expected.to have_http_status(400)
+            expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: false })
           end
         end
       end
     end
 
-    context 'with incorrect params' do
+    context 'when current_user is not a project owner' do
       before do
-        # Card::NoteCardのtitle, descriptionにはバリデーションがあるが
-        # card.js.coffeeのvalidateForm(event, is_note_card_form)でもalertを出している
-        patch :update,
-          params: { owner_name: user, project_id: project, id: note_card.id, note_card: { title: '', description: '' } },
-          xhr: true
+        sign_in(FactoryBot.create(:user))
+
+        post :create, params: { owner_name: user, project_id: project, note_card: new_note_card.attributes }, xhr: true
+        project.reload
       end
-      it do
-        aggregate_failures do
-          is_expected.to have_http_status(400)
-          expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: false })
+      it { is_expected.to_not render_template :create }
+      it 'does not create a note card' do
+        expect(project.note_cards.count).to eq 0
+      end
+    end
+  end
+
+  describe 'PATCH update' do
+    context 'when current_user is a project owner' do
+      before { sign_in(user) }
+      context 'with correct params' do
+        let(:title_to_change) { '_foo' }
+        let(:description_to_change) { '_bar' }
+
+        context 'with a title only' do
+          before do
+            patch :update,
+              params: { owner_name: user, project_id: project, id: note_card.id, note_card: { title: title_to_change } },
+              xhr: true
+            note_card.reload
+          end
+          it { is_expected.to render_template :update }
+          it { expect(project.note_cards.first.title).to eq title_to_change }
         end
+        context 'with a title and a description' do
+          before do
+            patch :update,
+              params: {
+                owner_name: user, project_id: project, id: note_card.id,
+                note_card: { title: title_to_change, description: description_to_change }
+              },
+              xhr: true
+            note_card.reload
+          end
+          it { is_expected.to render_template :update }
+          it 'should change both a title and a description' do
+            aggregate_failures do
+              note_card = project.note_cards.first
+              expect(note_card.title).to eq title_to_change
+              expect(note_card.description).to eq description_to_change
+            end
+          end
+        end
+      end
+
+      context 'with incorrect params' do
+        before do
+          # Card::NoteCardのtitle, descriptionにはバリデーションがあるが
+          # card.js.coffeeのvalidateForm(event, is_note_card_form)でもalertを出している
+          patch :update,
+            params: { owner_name: user, project_id: project, id: note_card.id, note_card: { title: '', description: '' } },
+            xhr: true
+        end
+        it do
+          aggregate_failures do
+            is_expected.to have_http_status(400)
+            expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: false })
+          end
+        end
+      end
+    end
+
+    context 'when current_user is not a project owner' do
+      let(:title_to_change) { '_foo' }
+      before do
+        sign_in(FactoryBot.create(:user))
+
+        patch :update,
+              params: { owner_name: user, project_id: project, id: note_card.id, note_card: { title: title_to_change } },
+              xhr: true
+        note_card.reload
+      end
+
+      it { is_expected.to have_http_status(400) }
+      it { expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: false }) }
+      it 'does not change a note card' do
+        expect(note_card.title).to_not eq title_to_change
       end
     end
   end
 
   describe 'DELETE destroy' do
-    before do
-      delete :destroy, params: { owner_name: user, project_id: project, id: note_card.id }, xhr: true
-      project.reload
+    context 'when current_user is a project owner' do
+      before do
+        sign_in(user)
+
+        delete :destroy, params: { owner_name: user, project_id: project, id: note_card.id }, xhr: true
+        project.reload
+      end
+      it { expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: true }) }
+      it 'has 0 note_cards' do
+        expect(project.note_cards.count).to eq 0
+      end
     end
-    it { expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: true }) }
-    it 'has 0 note_cards' do
-      expect(project.note_cards_count).to eq 0
+
+    context 'when current_user is not a project owner' do
+      before do
+        sign_in(FactoryBot.create(:user))
+
+        delete :destroy, params: { owner_name: user, project_id: project, id: note_card.id }, xhr: true
+        project.reload
+      end
+      it { is_expected.to have_http_status(400) }
+      it { expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: false }) }
+      it 'does not deletes a note card' do
+        expect(project.note_cards.count).to_not eq 0
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要

メモに対しての権限のspecを追加

## 変更内容

- プロジェクトのメモについての権限のspecを追加
- プロジェクトの権限がなくてもメモの追加、編集、削除ができる不具合を修正
