### PR TITLE
ユセージの権限についてのspecを拡充

### DIFF
--- a/spec/controllers/usages_controller_spec.rb
+++ b/spec/controllers/usages_controller_spec.rb
@@ -27,35 +27,104 @@ describe UsagesController, type: :controller do
   end
 
   describe 'POST create' do
-    before do
-      sign_in owner
-      project.usages.destroy_all
-      post :create, params: { owner_name: owner, project_id: project.name, usage: { title: 'title' } }, xhr: true
-      project.reload
+    context 'when a user is logged in' do
+      before do
+        sign_in owner
+        project.usages.destroy_all
+        post :create, params: { owner_name: owner, project_id: project.name, usage: { title: 'title' } }, xhr: true
+        project.reload
+      end
+      it { is_expected.to render_template :create }
+      it 'has 1 usage' do
+        expect(project.usages.count).to eq 1
+      end
     end
-    it { is_expected.to render_template :create }
-    it 'has 1 usage' do
-      expect(project.usages.size).to eq 1
+
+    context 'when a user is not logged in' do
+      before do
+        project.usages.destroy_all
+        post :create, params: { owner_name: owner, project_id: project.name, usage: { title: 'title' } }, xhr: true
+        project.reload
+      end
+      it { is_expected.to_not render_template :create }
+      it 'does not create a usage' do
+        expect(project.usages.count).to eq 0
+      end
     end
   end
 
   describe 'PATCH update' do
-    before do
-      sign_in owner
-      usage = FactoryBot.create(:usage, project: project, title: 'foo', description: 'bar')
-      patch :update,
-        params: { owner_name: owner, project_id: project, id: usage.id, usage: { title: 'title' } },
-        xhr: true
+    context 'when current_user is a project owner' do
+      before do
+        sign_in owner
+        usage = FactoryBot.create(:usage, project: project, title: 'foo', description: 'bar')
+        patch :update,
+          params: { owner_name: owner, project_id: project, id: usage.id, usage: { title: 'title' } },
+          xhr: true
+      end
+      it { is_expected.to render_template :update }
     end
-    it { is_expected.to render_template :update }
+
+    context 'when current_user is a contributor' do
+      before do
+        contributor = FactoryBot.create(:user)
+        sign_in contributor
+        
+        usage = FactoryBot.create(:usage, project: project, title: 'foo', description: 'bar')
+        FactoryBot.create(:contribution, contributor: contributor, card: usage)
+        patch :update,
+          params: { owner_name: owner, project_id: project, id: usage.id, usage: { title: 'title' } },
+          xhr: true
+      end
+      it { is_expected.to render_template :update }
+    end
+
+    context 'when current_user is not a contributor' do
+      before do
+        sign_in FactoryBot.create(:user)
+
+        usage = FactoryBot.create(:usage, project: project, title: 'foo', description: 'bar')
+        patch :update,
+          params: { owner_name: owner, project_id: project, id: usage.id, usage: { title: 'title' } },
+          xhr: true
+      end
+      it { is_expected.to_not render_template :update }
+    end
   end
 
   describe 'DELETE destroy' do
-    before do
-      sign_in owner
-      usage = FactoryBot.create(:usage, project: project, title: 'foo', description: 'bar')
-      delete :destroy, params: { owner_name: owner.to_param, project_id: project, id: usage.id }, xhr: true
+    context 'when current_user is a project owner' do
+      before do
+        sign_in owner
+
+        usage = FactoryBot.create(:usage, project: project, title: 'foo', description: 'bar')
+        delete :destroy, params: { owner_name: owner.to_param, project_id: project, id: usage.id }, xhr: true
+      end
+      it { is_expected.to have_http_status(:ok) }
+      it { expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: true }) }
     end
-    it { expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: true }) }
+
+    context 'when current_user is a contributor' do
+      before do
+        contributor = FactoryBot.create(:user)
+        sign_in contributor
+
+        usage = FactoryBot.create(:usage, project: project, title: 'foo', description: 'bar')
+        FactoryBot.create(:contribution, contributor: contributor, card: usage)
+        delete :destroy, params: { owner_name: owner.to_param, project_id: project, id: usage.id }, xhr: true
+      end
+      it { is_expected.to have_http_status(:ok) }
+      it { expect(JSON.parse(response.body, symbolize_names: true)).to eq({ success: true }) }
+    end
+    
+    context 'when current_user is not a contributor' do
+      before do
+        sign_in FactoryBot.create(:user)
+
+        usage = FactoryBot.create(:usage, project: project, title: 'foo', description: 'bar')
+        delete :destroy, params: { owner_name: owner.to_param, project_id: project, id: usage.id }, xhr: true
+      end
+      it { is_expected.to have_http_status(:unauthorized) }
+    end
   end
 end


### PR DESCRIPTION
## 概要

ユセージの権限についてのspecを拡充

## 変更内容

- プロジェクトのユセージについての権限のspecを追加
  - 作成：すべてのユーザー
  - 更新：ユセージの作成者とプロジェクトのエディター・管理者
  - 削除：ユセージの作成者とプロジェクトのエディター・管理者
