### PR TITLE
デプロイの際にcrontabファイルを更新する

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,7 +6,8 @@ set :rvm_type, :system
 set :rvm_ruby_version, '2.6.6'
 set :assets_roles, [:web, :app]
 set :npm_flags, '--silent --no-progress' # Not use --production to install devDependencies
-set :whenever_command, -> { "cd #{release_path} && bundle exec whenever" }
+set :whenever_command, -> { "cd #{release_path} && bundle exec whenever --update-crontab -i gitfab2" }
+set :whenever_roles, -> { :cron }
 
 if ENV['DEPLOY_BRANCH']
   set :branch, ENV['DEPLOY_BRANCH']

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
 role :app, %w(deploy@localhost)
 role :web, %w(deploy@localhost)
 role :db,  %w(deploy@localhost)
-server 'localhost', user: 'deploy', roles: %w(web app)
+server 'localhost', user: 'deploy', roles: %w(web app cron)
 set :rails_env, 'production'
 set :linked_files, %w{config/database.yml config/secrets.yml}

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,6 +1,6 @@
 role :app, %w(deploy@localhost)
 role :web, %w(deploy@localhost)
 role :db,  %w(deploy@localhost)
-server 'localhost', user: 'deploy', roles: %w(web app)
+server 'localhost', user: 'deploy', roles: %w(web app cron)
 set :rails_env, 'staging'
 set :linked_files, %w{config/database.yml config/secrets.yml}


### PR DESCRIPTION
`bundle exec cap production deploy` によるデプロイの際に `cd /usr/local/rails_apps/gitfab2/releases/20201001073552 && bundle exec whenever --update-crontab -i gitfab2` を実行してcrontabファイルを更新する。

```bash
$ bundle exec  cap production deploy
$ crontab -e

# Begin Whenever generated tasks for: gitfab2 at: 2020-10-01 16:37:54 +0900
0 20 * * * /bin/bash -l -c 'cd /usr/local/rails_apps/gitfab2/releases/20201001073615 && RAILS_ENV=production bundle exec rake backup:delete --silent'

30 0 * * * /bin/bash -l -c 'cd /usr/local/rails_apps/gitfab2/releases/20201001073615 && RAILS_ENV=production bundle exec rake statistic:daily --silent'

0 * * * * /bin/bash -l -c 'cd /usr/local/rails_apps/gitfab2/releases/20201001073615 && bundle exec bin/rails runner -e production '\''Rails.cache.clear'\'''

# End Whenever generated tasks for: gitfab2 at: 2020-10-01 16:37:54 +0900
```