### PR TITLE
スライド表示の際にスライド順が反映されない不具合を修正

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -143,9 +143,10 @@ class ProjectsController < ApplicationController
   end
 
   def slideshow
-    @project = @owner.projects.active.includes(states: [:figures, annotations: :figures])
-                 .friendly.find(params[:project_id])
-    @cards = @project.states.ordered_by_position.map { |state| [state] + state.annotations.ordered_by_position }.flatten
+    @project = @owner.projects.active.friendly.find(params[:project_id])
+    @cards = @project.states.includes(:figures).ordered_by_position.map { |state|
+      [state] + state.annotations.includes(:figures).ordered_by_position
+    }.flatten
     render layout: nil
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -145,7 +145,7 @@ class ProjectsController < ApplicationController
   def slideshow
     @project = @owner.projects.active.includes(states: [:figures, annotations: :figures])
                  .friendly.find(params[:project_id])
-    @cards = @project.states.map { |state| [state] + state.annotations }.flatten
+    @cards = @project.states.ordered_by_position.map { |state| [state] + state.annotations.ordered_by_position }.flatten
     render layout: nil
   end
 


### PR DESCRIPTION
## 現象

fabbleの「change order」で順番を変えたあと、スライド表示するとスライドの順番にchange orderが反映されない。

## 再現方法

private projectでいくつか「Add state」をして項目を追加、その後順番を「change order」で変えた
（os osx, browser Chrome(87.0.4280.67)）、（プライベートプロジェクトで発生）

## 修正内容

スライド表示の際に「表示順」でソートするようにした

