### PR TITLE
MySQLコンテナの起動に失敗する問題を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     image: mysql:5.6
     command: '--innodb-file-format=Barracuda --innodb-file-per-table=true --innodb-large-prefix=true --max-allowed-packet=32MB'
     environment:
-      MYSQL_USER: root
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
       MYSQL_ROOT_HOST: '%'
       TZ: /usr/share/zoneinfo/Asia/Tokyo


### PR DESCRIPTION
MYSQL_USER=root ではコンテナを起動できなくなっているので修正する。（ `MYSQL_USER` はユーザを作成するので `root` には使用できなくなった ）

今回はパスワード無しの root を使用したいので MYSQL_USER を削る
